### PR TITLE
Fix memory leak in Signature.decode()

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -18,6 +18,19 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    // Run module unit tests
+    {
+        const unit_tests = b.addTest(.{
+            .root_source_file = b.path("src/lib.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
+
+        const run_unit_tests = b.addRunArtifact(unit_tests);
+        const unit_test_step = b.step("test", "Run module unit tests.");
+        unit_test_step.dependOn(&run_unit_tests.step);
+    }
+
     // Build minzign cli
     {
         const exe = b.addExecutable(.{

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -15,7 +15,7 @@ const Ed25519 = crypto.sign.Ed25519;
 const Endian = std.builtin.Endian;
 
 pub const Signature = struct {
-    allocator: mem.Allocator,
+    arena: heap.ArenaAllocator,
     untrusted_comment: []u8,
     signature_algorithm: [2]u8,
     key_id: [8]u8,
@@ -24,8 +24,7 @@ pub const Signature = struct {
     global_signature: [64]u8,
 
     pub fn deinit(self: *Signature) void {
-        self.allocator.free(self.untrusted_comment);
-        self.allocator.free(self.trusted_comment);
+        self.arena.deinit();
     }
 
     pub const Algorithm = enum { Prehash, Legacy };
@@ -36,7 +35,9 @@ pub const Signature = struct {
         return if (prehashed) .Prehash else .Legacy;
     }
 
-    pub fn decode(allocator: mem.Allocator, lines_str: []const u8) !Signature {
+    pub fn decode(child_allocator: mem.Allocator, lines_str: []const u8) !Signature {
+        var arena = heap.ArenaAllocator.init(child_allocator);
+        errdefer arena.deinit();
         var it = mem.tokenizeScalar(u8, lines_str, '\n');
         const untrusted_comment = it.next() orelse return error.InvalidEncoding;
         var bin1: [74]u8 = undefined;
@@ -48,17 +49,15 @@ pub const Signature = struct {
         trusted_comment = trusted_comment["Trusted comment: ".len..];
         var bin2: [64]u8 = undefined;
         try base64.standard.Decoder.decode(&bin2, it.next() orelse return error.InvalidEncoding);
-        const untrusted_dupe = try allocator.dupe(u8, untrusted_comment);
-        errdefer allocator.free(untrusted_dupe);
-        const trusted_dupe = try allocator.dupe(u8, trusted_comment);
-        errdefer allocator.free(trusted_dupe);
+        const untrusted_comment_dupe = try arena.allocator().dupe(u8, untrusted_comment);
+        const trusted_comment_dupe = try arena.allocator().dupe(u8, trusted_comment);
         const sig = Signature{
-            .allocator = allocator,
-            .untrusted_comment = untrusted_dupe,
+            .arena = arena,
+            .untrusted_comment = untrusted_comment_dupe,
             .signature_algorithm = bin1[0..2].*,
             .key_id = bin1[2..10].*,
             .signature = bin1[10..74].*,
-            .trusted_comment = trusted_dupe,
+            .trusted_comment = trusted_comment_dupe,
             .global_signature = bin2,
         };
         return sig;

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -61,6 +61,16 @@ pub const Signature = struct {
         return sig;
     }
 
+    test "decode() does not leak" {
+        var signature = try decode(std.testing.allocator,
+            \\untrusted comment: signature from minisign secret key
+            \\RUSGOq2NVecA2aM2pTseOP756a29t33Ac9gE9f4jZuoXQVXNZ2kYoeVTuKOER5uQNPfZ+SdBa8uSCIyewXIbAaWWltW5ouG/rwQ=
+            \\trusted comment: timestamp:1717729444	file:zig-linux-x86_64-0.13.0.tar.xz	hashed
+            \\7Oots3dd6k0N8skNUp9hoi9cqp1R9Egp4k5AMkj45qLNQ4loF/7fc2L0wtfSdMd3JAE4zrAQSiOx8qj3dEI4DA==
+        );
+        defer signature.deinit();
+    }
+
     pub fn fromFile(allocator: mem.Allocator, path: []const u8) !Signature {
         const fd = try fs.cwd().openFile(path, .{ .mode = .read_only });
         defer fd.close();
@@ -257,3 +267,7 @@ pub const Verifier = struct {
         try Ed25519.Signature.fromBytes(self.sig.global_signature).verify(global, ed25519_pk);
     }
 };
+
+test {
+    _ = Signature;
+}


### PR DESCRIPTION
`Signature.decode()` followed by `Signature.deinit()` leaked memory.

My best guess for why this was happening is that there is a pointer somewhere in the internals of `std.heap.ArenaAllocator` that gets invalidated when the `ArenaAllocator` is copied from the function scope into the `Signature` and returned from `Signature.decode()`. However, I'm not familiar enough with `ArenaAllocator`'s internals to be confident in that.

I solved the issue by removing the `ArenaAllocator` and using the supplied `std.mem.Allocator` directly. This required the following:
- Move the `Allocator.dupe()` calls before of the struct initialization so that they may have their own `errdefer`'d calls to `Allocator.free()`. Strictly speaking, only the first `errdefer` is necessary, since there are no more opportunities for errors following the second call to `Allocator.dupe()`, but I've included both in case the code is rearranged in the future.
- Replace the `ArenaAllocator` field in `Signature` with a plain `Allocator`.
- Free the `trusted_comment` and `untrusted_comment` fields individually in `Signature.deinit()`.
