### PR TITLE
feat: add `build.zig.zon`

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,13 @@
+.{
+    .name = "zig-minisign",
+    .version = "0.1.5",
+    // TODO: when zig 0.14.0 release, we can use this
+    //.minimum_zig_version = "0.14.0",
+    .dependencies = .{
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}


### PR DESCRIPTION
This allows others to import this package

When `0.14.0` release, we can tag `0.1.5`, then set minimal version