### PR TITLE
introduce option to disable cli and make clap lazy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .zig-cache
 zig-cache
 zig-out
+zig-pkg
 *~
 .swival

--- a/build.zig
+++ b/build.zig
@@ -21,11 +21,17 @@ pub fn build(b: *std.Build) void {
     const resolved_target = target.result;
     const is_freestanding = resolved_target.os.tag == .freestanding;
 
-    if (!is_freestanding) {
-        const clap = b.dependency("clap", .{
+    const no_cli = b.option(
+        bool,
+        "no-cli",
+        "do not build the command line tool",
+    ) orelse is_freestanding;
+
+    if (!no_cli) cli: {
+        const clap = b.lazyDependency("clap", .{
             .target = target,
             .optimize = optimize,
-        });
+        }) orelse break :cli;
 
         // Build minzign cli
         const exe = b.addExecutable(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -14,6 +14,7 @@
         .clap = .{
             .url = "git+https://github.com/Hejsil/zig-clap#e91d66b1abba2024cd2e816426f14d233d3dad9a",
             .hash = "clap-0.12.0-oBajB2LpAQD1BQpAukHcuwhIUoHWYNy2DzU6lDW2v2N8",
+            .lazy = true,
         },
     },
 }


### PR DESCRIPTION
Hi Frank,

Consumers of this package with the zig package manager might not want to use the command line and instead just use the module, so an option
to disable fetching clap would be nice.

Best Regards,
Tobias